### PR TITLE
Update plugin for more recent GHC versions

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.0
+resolver: lts-14.1
 
 packages:
 - '.'


### PR DESCRIPTION
The `EvTerm` updates necessary for `QuantifiedConstraints` mean this plugin doesn't work on the latest GHC. This PR offers an immediate fix, but breaks backwards compatibility. If that's a priority for you, let me know and I'm happy to go sprinkle some ifdefs around.